### PR TITLE
Fix super parameters order

### DIFF
--- a/shared/src/main/scala/mlscript/JSBackend.scala
+++ b/shared/src/main/scala/mlscript/JSBackend.scala
@@ -849,69 +849,6 @@ class JSBackend(allowUnresolvedSymbols: Boolean) {
   
 }
 
-class JSCompilerBackend extends JSBackend(allowUnresolvedSymbols = true) {
-  private def generateNewDef(pgrm: Pgrm): Ls[Str] = {
-    val mlsModule = topLevelScope.declareValue("typing_unit", Some(false), false)
-    val (diags, (typeDefs, otherStmts)) = pgrm.newDesugared
-
-    val (traitSymbols, classSymbols, mixinSymbols, moduleSymbols, superParameters) = declareNewTypeDefs(typeDefs)
-    def include(typeName: Str, moduleName: Str) =
-      JSExprStmt(JSAssignExpr(JSField(JSIdent("globalThis"), typeName), JSField(JSIdent(moduleName), typeName)))
-    val includes =
-      traitSymbols.map((sym) => include(sym.runtimeName, mlsModule.runtimeName)) ++
-      mixinSymbols.map((sym) => include(sym.runtimeName, mlsModule.runtimeName)) ++
-      moduleSymbols.map((sym) => include(sym.runtimeName, mlsModule.runtimeName)) ++
-      classSymbols.map((sym) => include(sym.runtimeName, mlsModule.runtimeName)).toList
-
-    val defs =
-      traitSymbols.map { translateTraitDeclaration(_)(topLevelScope) } ++
-      mixinSymbols.map { translateMixinDeclaration(_)(topLevelScope) } ++
-      moduleSymbols.map((m) =>
-        translateModuleDeclaration(m, superParameters.get(m.runtimeName) match {
-          case Some(lst) => lst
-          case _ => Nil
-        })(topLevelScope)
-      ) ++
-      classSymbols.map { sym =>
-        superParameters.get(sym.runtimeName) match {
-          case Some(sp) => translateNewClassDeclaration(sym, sp)(topLevelScope)
-          case _ => translateNewClassDeclaration(sym)(topLevelScope)
-        }
-      }.toList
-
-    val defStmts =
-      JSLetDecl(Ls(mlsModule.runtimeName -> S(JSRecord(Ls("cache" -> JSRecord(Ls())), defs)))) :: includes
-
-    val stmts: Ls[JSStmt] =
-        defStmts
-        .concat(otherStmts.flatMap {
-          case Def(recursive, Var(name), L(body), isByname) =>
-            val (originalExpr, sym) = if (recursive) {
-              val isByvalueRecIn = if (isByname) None else Some(true)
-              val sym = topLevelScope.declareValue(name, isByvalueRecIn, body.isInstanceOf[Lam])
-              val translated = translateTerm(body)(topLevelScope)
-              topLevelScope.unregisterSymbol(sym)
-              val isByvalueRecOut = if (isByname) None else Some(false)
-              (translated, topLevelScope.declareValue(name, isByvalueRecOut, body.isInstanceOf[Lam]))
-            } else {
-              val translatedBody = translateTerm(body)(topLevelScope)
-              val isByvalueRec = if (isByname) None else Some(false)
-              (translatedBody, topLevelScope.declareValue(name, isByvalueRec, body.isInstanceOf[Lam]))
-            }
-            val translatedBody = if (sym.isByvalueRec.isEmpty && !sym.isLam) JSArrowFn(Nil, L(originalExpr)) else originalExpr
-            topLevelScope.tempVars `with` JSConstDecl(sym.runtimeName, translatedBody) :: Nil
-          // Ignore type declarations.
-          case Def(_, _, R(_), isByname) => Nil
-          // `exprs.push(<expr>)`.
-          case term: Term =>
-            translateTerm(term)(topLevelScope).stmt :: Nil
-        })
-    SourceCode.fromStmts(polyfill.emit() ::: stmts).toLines
-  }
-
-  def apply(pgrm: Pgrm): Ls[Str] = generateNewDef(pgrm)
-}
-
 class JSWebBackend extends JSBackend(allowUnresolvedSymbols = true) {
   // Name of the array that contains execution results
   val resultsName: Str = topLevelScope declareRuntimeSymbol "results"

--- a/shared/src/main/scala/mlscript/JSBackend.scala
+++ b/shared/src/main/scala/mlscript/JSBackend.scala
@@ -541,7 +541,7 @@ class JSBackend(allowUnresolvedSymbols: Boolean) {
         case (_, Fld(mut, spec, trm)) => translateTerm(trm)(getterScope)
       }
       case _ => Nil
-    }).flatten
+    }).map(_.reverse).flatten
     val decl = JSClassNewDecl(moduleSymbol.runtimeName,
                    fields,
                    base,
@@ -619,7 +619,7 @@ class JSBackend(allowUnresolvedSymbols: Boolean) {
         case (_, Fld(mut, spec, trm)) => translateTerm(trm)(constructorScope)
       }
       case _ => Nil
-    }).flatten
+    }).map(_.reverse).flatten
 
     JSClassNewDecl(classSymbol.runtimeName, fields, base, restRuntime match {
       case Some(restRuntime) => superParameters.reverse :+ JSIdent(s"...$restRuntime")
@@ -847,6 +847,69 @@ class JSBackend(allowUnresolvedSymbols: Boolean) {
     sorted.flatMap(sym => if (classSymbols.contains(sym)) S(sym -> baseClasses.get(sym)) else N)
   }
   
+}
+
+class JSCompilerBackend extends JSBackend(allowUnresolvedSymbols = true) {
+  private def generateNewDef(pgrm: Pgrm): Ls[Str] = {
+    val mlsModule = topLevelScope.declareValue("typing_unit", Some(false), false)
+    val (diags, (typeDefs, otherStmts)) = pgrm.newDesugared
+
+    val (traitSymbols, classSymbols, mixinSymbols, moduleSymbols, superParameters) = declareNewTypeDefs(typeDefs)
+    def include(typeName: Str, moduleName: Str) =
+      JSExprStmt(JSAssignExpr(JSField(JSIdent("globalThis"), typeName), JSField(JSIdent(moduleName), typeName)))
+    val includes =
+      traitSymbols.map((sym) => include(sym.runtimeName, mlsModule.runtimeName)) ++
+      mixinSymbols.map((sym) => include(sym.runtimeName, mlsModule.runtimeName)) ++
+      moduleSymbols.map((sym) => include(sym.runtimeName, mlsModule.runtimeName)) ++
+      classSymbols.map((sym) => include(sym.runtimeName, mlsModule.runtimeName)).toList
+
+    val defs =
+      traitSymbols.map { translateTraitDeclaration(_)(topLevelScope) } ++
+      mixinSymbols.map { translateMixinDeclaration(_)(topLevelScope) } ++
+      moduleSymbols.map((m) =>
+        translateModuleDeclaration(m, superParameters.get(m.runtimeName) match {
+          case Some(lst) => lst
+          case _ => Nil
+        })(topLevelScope)
+      ) ++
+      classSymbols.map { sym =>
+        superParameters.get(sym.runtimeName) match {
+          case Some(sp) => translateNewClassDeclaration(sym, sp)(topLevelScope)
+          case _ => translateNewClassDeclaration(sym)(topLevelScope)
+        }
+      }.toList
+
+    val defStmts =
+      JSLetDecl(Ls(mlsModule.runtimeName -> S(JSRecord(Ls("cache" -> JSRecord(Ls())), defs)))) :: includes
+
+    val stmts: Ls[JSStmt] =
+        defStmts
+        .concat(otherStmts.flatMap {
+          case Def(recursive, Var(name), L(body), isByname) =>
+            val (originalExpr, sym) = if (recursive) {
+              val isByvalueRecIn = if (isByname) None else Some(true)
+              val sym = topLevelScope.declareValue(name, isByvalueRecIn, body.isInstanceOf[Lam])
+              val translated = translateTerm(body)(topLevelScope)
+              topLevelScope.unregisterSymbol(sym)
+              val isByvalueRecOut = if (isByname) None else Some(false)
+              (translated, topLevelScope.declareValue(name, isByvalueRecOut, body.isInstanceOf[Lam]))
+            } else {
+              val translatedBody = translateTerm(body)(topLevelScope)
+              val isByvalueRec = if (isByname) None else Some(false)
+              (translatedBody, topLevelScope.declareValue(name, isByvalueRec, body.isInstanceOf[Lam]))
+            }
+            val translatedBody = if (sym.isByvalueRec.isEmpty && !sym.isLam) JSArrowFn(Nil, L(originalExpr)) else originalExpr
+            topLevelScope.tempVars `with` JSConstDecl(sym.runtimeName, translatedBody) :: Nil
+          // Ignore type declarations.
+          case Def(_, _, R(_), isByname) => Nil
+          // `exprs.push(<expr>)`.
+          case term: Term =>
+            translateTerm(term)(topLevelScope).stmt :: Nil
+        })
+    SourceCode.fromStmts(polyfill.emit() ::: stmts).toLines
+  }
+
+  def apply(pgrm: Pgrm): Ls[Str] = generateNewDef(pgrm)
 }
 
 class JSWebBackend extends JSBackend(allowUnresolvedSymbols = true) {

--- a/shared/src/test/diff/codegen/Mixin.mls
+++ b/shared/src/test/diff/codegen/Mixin.mls
@@ -527,3 +527,46 @@ module Test extends Base
 //│ }
 //│ Runtime error:
 //│   ReferenceError: Base is not defined
+
+mixin MA(a: int)
+mixin MB(b1: int, b2: int)
+mixin MC(c: int)
+//│ mixin MA(a: int)
+//│ mixin MB(b1: int, b2: int)
+//│ mixin MC(c: int)
+
+:js
+module MM extends MA(1), MB(2, 3), MC(4)
+//│ module MM()
+//│ // Prelude
+//│ let typing_unit22 = {
+//│   cache: {},
+//│   get MM() {
+//│     if (this.cache.MM === undefined) {
+//│       class MM extends MC(MB(MA(Object))) {
+//│         constructor() {
+//│           super(4, 2, 3, 1);
+//│         }
+//│       }
+//│       this.cache.MM = new MM();
+//│       this.cache.MM["class"] = MM;
+//│     }
+//│     return this.cache.MM;
+//│   }
+//│ };
+//│ globalThis.MM = typing_unit22.MM;
+//│ // End of generated code
+
+MM.a
+MM.b1
+MM.b2
+MM.c
+//│ 4
+//│ res
+//│     = 1
+//│ res
+//│     = 2
+//│ res
+//│     = 3
+//│ res
+//│     = 4


### PR DESCRIPTION
before:
```
MM.a
MM.b1
MM.b2
MM.c
//│ 4
//│ res
//│     = 1
//│ res
//│     = 3
//│ res
//│     = 2
//│ res
//│     = 4
```

after:
```
MM.a
MM.b1
MM.b2
MM.c
//│ 4
//│ res
//│     = 1
//│ res
//│     = 2
//│ res
//│     = 3
//│ res
//│     = 4
```